### PR TITLE
fix(audio): sync audio playback position with timeline seek

### DIFF
--- a/apps/web/src/components/editor/Preview.tsx
+++ b/apps/web/src/components/editor/Preview.tsx
@@ -1889,6 +1889,7 @@ export const Preview: React.FC = () => {
 
       await audioGraph.resume();
       audioGraph.seekTo(startPosition);
+      await masterClock.play();
       audioGraph.startScheduler(() => {
         const tracksWithAudio = timelineTracks.filter(
           (t) => (t.type === "audio" || t.type === "video") && !t.hidden,
@@ -1923,8 +1924,6 @@ export const Preview: React.FC = () => {
         }
         return schedules;
       });
-
-      await masterClock.play();
 
       let isActive = true;
       let rafId: number | null = null;
@@ -2855,9 +2854,8 @@ export const Preview: React.FC = () => {
       masterClock.seek(playbackStartPosition);
 
       audioGraph.seekTo(playbackStartPosition);
-      audioGraph.startScheduler(getAudioClipsForScheduler);
-
       await masterClock.play();
+      audioGraph.startScheduler(getAudioClipsForScheduler);
 
       const frameDuration = 1000 / 30;
       let lastFrameTimestamp = performance.now();

--- a/packages/core/src/audio/realtime-audio-graph.ts
+++ b/packages/core/src/audio/realtime-audio-graph.ts
@@ -73,6 +73,7 @@ export class RealtimeAudioGraph {
   private impulseResponseCache: Map<string, AudioBuffer> = new Map();
   private isPlaying = false;
   private lastScheduledTime = 0;
+  private seekPending = false;
   private scheduleAheadTime = 0.2;
   private schedulerIntervalId: number | null = null;
 
@@ -583,7 +584,10 @@ export class RealtimeAudioGraph {
     if (this.schedulerIntervalId !== null) return;
 
     this.isPlaying = true;
-    this.lastScheduledTime = this.masterClock.currentTime;
+    if (!this.seekPending) {
+      this.lastScheduledTime = this.masterClock.currentTime;
+    }
+    this.seekPending = false;
 
     const scheduleAudio = () => {
       if (!this.isPlaying) return;
@@ -628,6 +632,7 @@ export class RealtimeAudioGraph {
   seekTo(time: number): void {
     this.stopAllClips();
     this.lastScheduledTime = time;
+    this.seekPending = true;
   }
 
   dispose(): void {

--- a/packages/core/src/playback/master-timeline-clock.ts
+++ b/packages/core/src/playback/master-timeline-clock.ts
@@ -40,8 +40,8 @@ export class MasterTimelineClock {
   }
 
   get currentTime(): number {
-    if (this.state === "stopped") return 0;
-    if (this.state === "paused") return this.pausedAt;
+    if (this.state === "stopped" || this.state === "paused")
+      return this.pausedAt;
 
     const elapsed =
       (this.audioContext.currentTime - this.startAudioContextTime) *


### PR DESCRIPTION
## Summary
- Fixed audio always playing from the beginning of the video regardless of where the playhead is positioned on the timeline
- `MasterTimelineClock.currentTime` now correctly returns the seeked position in "stopped" state instead of always returning 0
- `RealtimeAudioGraph.startScheduler()` now respects the position set by `seekTo()` via a `seekPending` flag instead of unconditionally overwriting it
- Reordered `masterClock.play()` before `audioGraph.startScheduler()` in both native and multi-track playback paths in Preview.tsx

## Test plan
- [ ] Open the editor and add a video with audio
- [ ] Place video on the timeline
- [ ] Click on the timeline at various positions and press play — audio should match the video position
- [ ] Scrub along the timeline and press play — audio should start from the scrubbed position
- [ ] Play from the very beginning (time 0) — audio should still work correctly
- [ ] Pause and resume at different positions — audio should stay in sync
- [ ] Test with multiple clips on the timeline