### PR TITLE
fix: update audio mixer levels and loading

### DIFF
--- a/apps/web/src/components/editor/EditorInterface.tsx
+++ b/apps/web/src/components/editor/EditorInterface.tsx
@@ -6,6 +6,7 @@ import { Preview } from "./Preview";
 import { InspectorPanel } from "./InspectorPanel";
 import { Timeline } from "./Timeline";
 import { KeyframeEditorPanel } from "./KeyframeEditorPanel";
+import { AudioMixer } from "../audio-mixer";
 import { KeyboardShortcutsOverlay } from "./KeyboardShortcutsOverlay";
 import { PanelErrorBoundary } from "../ErrorBoundary";
 import { SpotlightTour, MoGraphTour } from "./tour";
@@ -165,7 +166,12 @@ export const EditorInterface: React.FC = () => {
     useKeyboardShortcuts();
   useAutoSave();
 
-  const { keyframeEditorOpen, setKeyframeEditorOpen, getSelectedClipIds } = useUIStore();
+  const {
+    keyframeEditorOpen,
+    getSelectedClipIds,
+    panels,
+    setPanelVisible,
+  } = useUIStore();
   const { project, updateClipKeyframes } = useProjectStore();
   const tracks = project.timeline.tracks;
 
@@ -334,6 +340,16 @@ export const EditorInterface: React.FC = () => {
       >
         <div className="absolute inset-x-0 -top-1 -bottom-1 bg-transparent" />
       </div>
+
+      {/* Audio Mixer (when open) */}
+      {panels.audioMixer?.visible && (
+        <PanelErrorBoundary name="Audio Mixer">
+          <AudioMixer
+            visible
+            onClose={() => setPanelVisible("audioMixer", false)}
+          />
+        </PanelErrorBoundary>
+      )}
 
       {/* BOTTOM PANEL: Timeline */}
       <div

--- a/apps/web/src/components/editor/Preview.tsx
+++ b/apps/web/src/components/editor/Preview.tsx
@@ -692,7 +692,7 @@ export const Preview: React.FC = () => {
       gainNodeRef.current.gain.value = isMuted ? 0 : 1;
     }
     if (audioGraphRef.current) {
-      audioGraphRef.current.setMasterVolume(isMuted ? 0 : 1);
+      audioGraphRef.current.setPreviewMuted(isMuted);
     }
   }, [isMuted]);
 
@@ -808,7 +808,7 @@ export const Preview: React.FC = () => {
         audioGraphRef.current = getRealtimeAudioGraph();
       }
       const audioGraph = audioGraphRef.current;
-      audioGraph.setMasterVolume(isMuted ? 0 : 1);
+      audioGraph.setPreviewMuted(isMuted);
 
       const projectStore = useProjectStore.getState();
       const speedEngine = getSpeedEngine();
@@ -1871,7 +1871,7 @@ export const Preview: React.FC = () => {
         audioGraphRef.current = getRealtimeAudioGraph();
       }
       const audioGraph = audioGraphRef.current;
-      audioGraph.setMasterVolume(isMuted ? 0 : 1);
+      audioGraph.setPreviewMuted(isMuted);
 
       const tracksWithAudio = timelineTracks.filter(
         (t) => (t.type === "audio" || t.type === "video") && !t.hidden,
@@ -2803,7 +2803,7 @@ export const Preview: React.FC = () => {
         audioGraphRef.current = getRealtimeAudioGraph();
       }
       const audioGraph = audioGraphRef.current;
-      audioGraph.setMasterVolume(isMuted ? 0 : 1);
+      audioGraph.setPreviewMuted(isMuted);
 
       const tracksWithAudio = timelineTracksRef.current.filter(
         (t) => (t.type === "audio" || t.type === "video") && !t.hidden,

--- a/apps/web/src/components/editor/Toolbar.tsx
+++ b/apps/web/src/components/editor/Toolbar.tsx
@@ -77,8 +77,15 @@ interface ExportState {
 
 export const Toolbar: React.FC = () => {
   const { project } = useProjectStore();
-  const { openModal, selectedItems, setExportState: setGlobalExportState, keyframeEditorOpen, toggleKeyframeEditor } =
-    useUIStore();
+  const {
+    openModal,
+    selectedItems,
+    setExportState: setGlobalExportState,
+    keyframeEditorOpen,
+    toggleKeyframeEditor,
+    panels,
+    togglePanel,
+  } = useUIStore();
   const { mode: themeMode, toggleTheme } = useThemeStore();
   const [isExportOpen, setIsExportOpen] = useState(false);
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
@@ -948,6 +955,24 @@ export const Toolbar: React.FC = () => {
           </TooltipTrigger>
           <TooltipContent>
             <p>Keyframe Editor</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => togglePanel("audioMixer")}
+              className={`p-2 rounded-lg transition-colors ${
+                panels.audioMixer?.visible
+                  ? "bg-primary/20 text-primary"
+                  : "hover:bg-background-elevated text-text-secondary hover:text-text-primary"
+              }`}
+            >
+              <Music size={16} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Audio Mixer – track volume and master level</p>
           </TooltipContent>
         </Tooltip>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,22 +18,6 @@ importers:
         specifier: ^1.25.3
         version: 1.25.3
 
-  apps/cloud:
-    dependencies:
-      hono:
-        specifier: ^4.11.4
-        version: 4.11.4
-    devDependencies:
-      '@cloudflare/workers-types':
-        specifier: ^4.20260117.0
-        version: 4.20260117.0
-      typescript:
-        specifier: ^5.5.2
-        version: 5.9.3
-      wrangler:
-        specifier: ^3.101.0
-        version: 3.114.17(@cloudflare/workers-types@4.20260117.0)
-
   apps/image:
     dependencies:
       '@imgly/background-removal':
@@ -2662,10 +2646,6 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
-  hono@4.11.4:
-    resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
-    engines: {node: '>=16.9.0'}
-
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -3872,7 +3852,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250718.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20260117.0': {}
+  '@cloudflare/workers-types@4.20260117.0':
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -5839,8 +5820,6 @@ snapshots:
   highlight.js@10.7.3: {}
 
   highlightjs-vue@1.0.0: {}
-
-  hono@4.11.4: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:


### PR DESCRIPTION
### Description
Exposes the Audio Mixer in the UI and fixes it so track and master volume actually affect playback. The mixer was implemented but not shown, and it was controlling a different audio path than the one used for preview.

- UI: Audio Mixer is rendered above the timeline and opened via the Music icon in the toolbar; panel visibility is driven by panels.audioMixer and can be closed with the header ✕ or by toggling the button again.
- Playback: Mixer now drives the same RealtimeAudioGraph used by Preview: track/master volumes are stored as overrides so they survive track recreation (e.g. on seek), and preview mute no longer overwrites the mixer’s master level.
- Robustness: Safe handling when the graph or project isn’t ready (try/catch, optional chaining for project.timeline, and checks for optional graph methods).

### Type of Change
[x] Bug fix (non-breaking change that fixes an issue)
[x] New feature (non-breaking change that adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update
[ ] Performance improvement
[ ] Code refactoring
[ ] Test coverage improvement

### Changes Made

- EditorInterface.tsx: Import and render AudioMixer above the timeline when panels.audioMixer.visible is true; wire onClose to setPanelVisible("audioMixer", false).
- Toolbar.tsx: Add Music icon button that calls togglePanel("audioMixer"); use panels and togglePanel from the UI store and show active state when the mixer is open.
- AudioMixer.tsx: Use getRealtimeAudioGraph() instead of getRealtimeAudioProcessor(); call updateTrackVolume, updateTrackPan, and setMasterVolume on the graph; sync initial volume/pan/master from the graph when the mixer opens; guard with try/catch and optional chaining for project?.timeline?.tracks; check for getMasterVolume / getTrackVolume / getTrackPan before calling.
- Preview.tsx: Replace setMasterVolume(isMuted ? 0 : 1) with setPreviewMuted(isMuted) so preview mute doesn’t overwrite the mixer’s master volume.
- realtime-audio-graph.ts: Add trackVolumeOverrides, trackPanOverrides, masterVolumeOverride, and previewMuted; createTrack uses overrides when present; setMasterVolume sets and applies master override; add setPreviewMuted() and applyMasterGain(); updateTrackVolume / updateTrackPan persist overrides; add getTrackVolume(), getTrackPan(), and getMasterVolume() for the mixer.

### Testing
Test Plan:
[x] All existing tests pass (pnpm test)
[ ] TypeScript compiles without errors (pnpm typecheck)
[ ] Added new tests for new functionality
[x] Manually tested in browser

### Browsers Tested:
[x] Chrome
[ ] Edge
[ ] Other: __

### Screenshots/Videos
Before:
Audio Mixer was not visible in the UI; no way to adjust track or master level from the app.
After:
Music icon in the toolbar opens the Audio Mixer above the timeline. Per-track volume faders (0–4, up to +12 dB) and master fader affect playback; closing the mixer or toggling the button hides the panel.

### Checklist
[x] My code follows the project's coding style (see CONTRIBUTING.md)
[x] I have performed a self-review of my own code
[x] I have commented complex/non-obvious code
[ ] I have updated relevant documentation
[x] My changes generate no new warnings or errors
[x] I have removed all console.log statements and debug code
[x] New and existing tests pass locally
[x] I have checked my code builds successfully

### Additional Context
The mixer previously controlled RealtimeAudioProcessor while Preview uses RealtimeAudioGraph; track volumes are now applied on the graph and persisted across track recreation so seek/play doesn’t reset levels. No existing tests were modified; none of them reference the audio graph or mixer.

**Note:** This PR will be reviewed by Claude AI within 24 hours. Claude will:
- Run automated checks (TypeScript, tests, linting)
- Provide detailed code review feedback
- Approve or request changes

Final approval and merge requires human review from Augustus.

Learn more about our [AI-managed workflow](.github/CLAUDE_WORKFLOW.md).
