### PR TITLE
fix: detect multiple audio streams via FFmpeg probe fallback

### DIFF
--- a/apps/web/src/stores/project-store.ts
+++ b/apps/web/src/stores/project-store.ts
@@ -1307,7 +1307,23 @@ export const useProjectStore = create<ProjectState>()(
         }
 
         // Determine how many audio tracks to separate
-        const audioTrackCount = mediaItem.metadata.audioTrackCount ?? 1;
+        let audioTrackCount = mediaItem.metadata.audioTrackCount ?? 1;
+
+        // Re-probe with FFmpeg if count is 1 or unset (handles legacy imports)
+        if (audioTrackCount <= 1 && mediaItem.blob) {
+          try {
+            const { getFFmpegFallback } = await import(
+              "@openreel/core/media"
+            );
+            const ffmpeg = getFFmpegFallback();
+            const probeResult = await ffmpeg.probeAudioStreams(mediaItem.blob);
+            if (probeResult.audioStreamCount > 1) {
+              audioTrackCount = probeResult.audioStreamCount;
+            }
+          } catch {
+            // FFmpeg probe unavailable — proceed with count of 1
+          }
+        }
 
         // Apply all track/add and clip/add actions on a single project copy to
         // avoid race conditions from multiple store updates.

--- a/packages/core/src/media/ffmpeg-fallback.ts
+++ b/packages/core/src/media/ffmpeg-fallback.ts
@@ -12,14 +12,27 @@ type FFmpegInstance = {
   exec(args: string[]): Promise<number>;
   on(
     event: string,
-    callback: (data: { progress: number; time?: number }) => void,
+    callback: (data: { progress?: number; time?: number; message?: string; type?: string }) => void,
   ): void;
   off(
     event: string,
-    callback?: (data: { progress: number; time?: number }) => void,
+    callback?: (data: { progress?: number; time?: number; message?: string; type?: string }) => void,
   ): void;
   terminate(): void;
 };
+
+export interface AudioStreamInfo {
+  index: number;
+  codec: string;
+  sampleRate: number;
+  channels: number;
+  channelLayout: string;
+}
+
+export interface AudioProbeResult {
+  audioStreamCount: number;
+  streams: AudioStreamInfo[];
+}
 
 export interface ProxySettings {
   scale: number;
@@ -87,7 +100,7 @@ export class FFmpegFallback {
   private loaded = false;
   private loading: Promise<void> | null = null;
   private progressCallback:
-    | ((data: { progress: number; time?: number }) => void)
+    | ((data: { progress?: number; time?: number; message?: string; type?: string }) => void)
     | null = null;
 
   private calculateBufsize(bitrate: string): string {
@@ -192,16 +205,17 @@ export class FFmpegFallback {
     }
 
     this.progressCallback = ({ progress, time }) => {
+      const p = progress ?? 0;
       let estimatedTimeRemaining = 0;
-      if (totalDuration && time && progress > 0) {
+      if (totalDuration && time && p > 0) {
         const elapsedTime = time / 1000000;
-        const rate = elapsedTime / progress;
-        estimatedTimeRemaining = (1 - progress) * rate;
+        const rate = elapsedTime / p;
+        estimatedTimeRemaining = (1 - p) * rate;
       }
 
       onProgress({
-        phase: progress < 1 ? "encoding" : "complete",
-        progress: Math.min(progress, 1),
+        phase: p < 1 ? "encoding" : "complete",
+        progress: Math.min(p, 1),
         currentFrame: 0,
         totalFrames: 0,
         estimatedTimeRemaining,
@@ -446,6 +460,70 @@ export class FFmpegFallback {
         hasAudio: true,
       };
     } finally {
+      await this.cleanupFiles([inputFilename]);
+    }
+  }
+
+  async probeAudioStreams(file: File | Blob): Promise<AudioProbeResult> {
+    await this.load();
+    this.ensureLoaded();
+
+    const inputFilename = `probe_${Date.now()}`;
+    const logLines: string[] = [];
+
+    const logHandler = (data: { message?: string }) => {
+      if (data.message) {
+        logLines.push(data.message);
+      }
+    };
+
+    try {
+      const inputData = await this.fileToUint8Array(file);
+      await this.ffmpeg!.writeFile(inputFilename, inputData);
+
+      this.ffmpeg!.on("log", logHandler);
+
+      try {
+        await this.ffmpeg!.exec(["-i", inputFilename, "-hide_banner"]);
+      } catch {
+        // FFmpeg exits with error code when no output specified — expected
+      }
+
+      this.ffmpeg!.off("log", logHandler);
+
+      const streams: AudioStreamInfo[] = [];
+      const streamRegex = /Stream #\d+:(\d+).*?: Audio: (\w+)/;
+      const sampleRateRegex = /(\d+) Hz/;
+      const channelRegex = /(mono|stereo|5\.1|7\.1|(\d+) channels)/;
+
+      for (const line of logLines) {
+        const streamMatch = line.match(streamRegex);
+        if (!streamMatch) continue;
+
+        const index = parseInt(streamMatch[1], 10);
+        const codec = streamMatch[2];
+
+        const srMatch = line.match(sampleRateRegex);
+        const sampleRate = srMatch ? parseInt(srMatch[1], 10) : 0;
+
+        const chMatch = line.match(channelRegex);
+        let channels = 2;
+        let channelLayout = "stereo";
+        if (chMatch) {
+          channelLayout = chMatch[1];
+          if (channelLayout === "mono") channels = 1;
+          else if (channelLayout === "stereo") channels = 2;
+          else if (channelLayout === "5.1") channels = 6;
+          else if (channelLayout === "7.1") channels = 8;
+          else if (chMatch[2]) channels = parseInt(chMatch[2], 10);
+        }
+
+        streams.push({ index, codec, sampleRate, channels, channelLayout });
+      }
+
+      return { audioStreamCount: streams.length, streams };
+    } finally {
+      this.ffmpeg!.off("log", logHandler);
       await this.cleanupFiles([inputFilename]);
     }
   }

--- a/packages/core/src/media/index.ts
+++ b/packages/core/src/media/index.ts
@@ -19,7 +19,7 @@ export {
   PROXY_PRESETS,
   PROXY_THRESHOLDS,
 } from "./ffmpeg-fallback";
-export type { ProxySettings, TranscodeOptions } from "./ffmpeg-fallback";
+export type { ProxySettings, TranscodeOptions, AudioProbeResult, AudioStreamInfo } from "./ffmpeg-fallback";
 
 // Media Import Service
 export {

--- a/packages/core/src/media/media-import-service.ts
+++ b/packages/core/src/media/media-import-service.ts
@@ -105,6 +105,21 @@ export class MediaImportService {
           error: "Could not determine media type",
         };
       }
+
+      if (
+        metadata.hasAudio &&
+        (metadata.audioTrackCount === undefined || metadata.audioTrackCount <= 1)
+      ) {
+        try {
+          const probeResult = await this.ffmpegFallback.probeAudioStreams(file);
+          if (probeResult.audioStreamCount > 1) {
+            metadata.audioTrackCount = probeResult.audioStreamCount;
+          }
+        } catch {
+          // FFmpeg probe failed — keep existing count
+        }
+      }
+
       if (!metadata.canDecode) {
         warnings.push(
           "Codec may not be fully supported. Playback might be limited.",
@@ -259,6 +274,18 @@ export class MediaImportService {
     // Now process with MediaBunny
     const metadata = await this.mediaEngine.extractMetadata(compatibleFile);
     const mediaType = inferMediaType(compatibleFile.type) || "video";
+
+    // Probe original file for audio tracks since WebM transcode may lose them
+    if (metadata.audioTrackCount === undefined || metadata.audioTrackCount <= 1) {
+      try {
+        const probeResult = await this.ffmpegFallback.probeAudioStreams(file);
+        if (probeResult.audioStreamCount > 1) {
+          metadata.audioTrackCount = probeResult.audioStreamCount;
+        }
+      } catch {
+        // FFmpeg probe failed — keep existing count
+      }
+    }
 
     let thumbnails: ThumbnailResult[] = [];
     if (opts.generateThumbnails && metadata.hasVideo) {


### PR DESCRIPTION
## Summary

- Adds `probeAudioStreams()` to FFmpegFallback that parses FFmpeg's `-i` log output to count audio streams
- At import time, if MediaBunny reports ≤1 audio track, runs FFmpeg probe on the original file as fallback
- In `separateAudio()`, re-probes legacy media that was imported before multi-track detection existed
- Probes the original file (not the transcoded WebM) to preserve multi-track info

## Problem

MediaBunny's `getAudioTracks()` silently fails for certain container formats (catches exception, defaults to 1). The FFmpeg fallback path transcodes to WebM before probing, potentially losing multi-track structure. Result: "Separate Audio" always produces one clip.

## Test plan

- [ ] Import a video with multiple audio streams (e.g. a film with stereo + commentary tracks)
- [ ] Right-click → Separate Audio
- [ ] Verify multiple audio clips appear on separate timeline tracks
- [ ] Verify single-audio-track videos still work as before (one clip)
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes

Fixes #31