### PR TITLE
docs: fix repository links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,7 +54,7 @@ Fixes #(issue number)
 ## Checklist
 
 <!-- Ensure all items are complete before submitting -->
-- [ ] My code follows the project's coding style (see [CONTRIBUTING.md](../../CONTRIBUTING.md))
+- [ ] My code follows the project's coding style (see [CONTRIBUTING.md](../CONTRIBUTING.md))
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented complex/non-obvious code
 - [ ] I have updated relevant documentation
@@ -76,4 +76,4 @@ Fixes #(issue number)
 
 Final approval and merge requires human review from Augustus.
 
-Learn more about our [AI-managed workflow](.github/CLAUDE_WORKFLOW.md).
+Learn more about our [AI-managed workflow](CLAUDE_WORKFLOW.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Be respectful, constructive, and professional. We're building something great to
 
 ```bash
 # 1. Fork and clone the repository
-git clone https://github.com/augani/openreel-video.git
+git clone https://github.com/Augani/openreel-video.git
 cd openreel-video
 
 # 2. Install dependencies
@@ -298,14 +298,14 @@ Brief description of changes
 ## Areas to Contribute
 
 ### 🐛 Bug Fixes
-- Check [Issues](https://github.com/augani/openreel/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+- Check [Issues](https://github.com/Augani/openreel-video/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 - Reproduce the bug
 - Write a failing test
 - Fix the bug
 - Verify the test passes
 
 ### ✨ New Features
-- Discuss in [Discussions](https://github.com/augani/openreel/discussions) first
+- Discuss in [Discussions](https://github.com/Augani/openreel-video/discussions) first
 - Get approval before large changes
 - Break into smaller PRs if possible
 - Update documentation
@@ -374,7 +374,7 @@ Changes to React components hot reload automatically. For core engine changes, y
 ## Questions?
 
 - **Discord**: [Join our Discord](https://discord.gg/openreeel)
-- **Discussions**: [GitHub Discussions](https://github.com/augani/openreel/discussions)
+- **Discussions**: [GitHub Discussions](https://github.com/Augani/openreel-video/discussions)
 - **Email**: contribute@openreeel.video
 
 ## Recognition

--- a/apps/web/DEPLOY_CHECKLIST.md
+++ b/apps/web/DEPLOY_CHECKLIST.md
@@ -148,4 +148,4 @@ Go to Cloudflare Dashboard → Pages → openreel → Deployments → Select pre
 For deployment issues:
 - Check logs: Cloudflare Pages → openreel → Deployments → [Latest] → View logs
 - Wrangler docs: https://developers.cloudflare.com/pages/
-- OpenReel issues: https://github.com/augani/openreel/issues
+- OpenReel issues: https://github.com/Augani/openreel-video/issues

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/augani/openreel.git"
+    "url": "https://github.com/Augani/openreel-video.git"
   },
   "bugs": {
-    "url": "https://github.com/augani/openreel/issues"
+    "url": "https://github.com/Augani/openreel-video/issues"
   },
   "homepage": "https://openreel.video",
   "engines": {


### PR DESCRIPTION
## Summary
- Update stale `augani/openreel` repository, issue, and discussion links to `Augani/openreel-video`.
- Fix local links in the pull request template so they resolve from `.github/pull_request_template.md`.

## Verification
- `gh repo view Augani/openreel-video`
- `python -m json.tool package.json`
- `git diff --check`
- Checked Markdown local links; 12 Markdown files checked, 0 missing links.
- Confirmed no remaining `github.com/augani/openreel` references outside the lockfile.