### PR TITLE
fix: clip-to-clip transitions in preview + export, keyframe effects, dropdown stacking

### DIFF
--- a/apps/web/src/components/editor/Preview.tsx
+++ b/apps/web/src/components/editor/Preview.tsx
@@ -2419,6 +2419,22 @@ export const Preview: React.FC = () => {
         return { canUse: false, clips: [] };
       }
 
+      // Native playback uses a single <video> element per active clip and a
+      // straight drawImage — it can't blend two clips, so any clip-to-clip
+      // transition in the playback range forces the multi-track path.
+      const hasUpcomingTransition = videoTracks.some((track) =>
+        track.transitions.some((t) => {
+          const clipA = track.clips.find((c) => c.id === t.clipAId);
+          if (!clipA) return false;
+          const transitionEnd =
+            clipA.startTime + clipA.duration + t.duration / 2;
+          return transitionEnd > startPosition;
+        }),
+      );
+      if (hasUpcomingTransition) {
+        return { canUse: false, clips: [] };
+      }
+
       if (allVideoClips.length === 0) return { canUse: false, clips: [] };
 
       allVideoClips.sort((a, b) => a.clip.startTime - b.clip.startTime);
@@ -3695,6 +3711,190 @@ export const Preview: React.FC = () => {
             }
           }
 
+          // Active transition takes over the whole frame: decode both clips
+          // (one will be outside its visible window — its sink will clamp to
+          // the nearest edge frame) and blend them. Overlays still render on
+          // top below.
+          const transitionInfoMulti = getTransitionAtTime(
+            currentPlayhead,
+            timelineTracksRef.current,
+          );
+
+          // Compute these here so they're visible in both the transition path
+          // and the normal compositing path below.
+          const activeShapeClips = getActiveShapeClips(
+            allShapeClipsRef.current,
+            currentPlayhead,
+          );
+          const activeTextClips = getActiveTextClips(
+            allTextClipsRef.current,
+            currentPlayhead,
+          );
+
+          if (transitionInfoMulti) {
+            const tracks = timelineTracksRef.current;
+            const findClipById = (id: string) => {
+              for (let idx = 0; idx < tracks.length; idx++) {
+                const found = tracks[idx].clips.find((c) => c.id === id);
+                if (found) return { clip: found, trackIndex: idx };
+              }
+              return null;
+            };
+
+            const aLookup = findClipById(transitionInfoMulti.clipA.id);
+            const bLookup = findClipById(transitionInfoMulti.clipB.id);
+
+            if (aLookup && bLookup) {
+              for (const lookup of [aLookup, bLookup]) {
+                if (!playbackResourcesRef.current.has(lookup.clip.id)) {
+                  const resources = await initClipResources(
+                    lookup.clip,
+                    lookup.trackIndex,
+                  );
+                  if (resources) {
+                    playbackResourcesRef.current.set(
+                      lookup.clip.id,
+                      resources,
+                    );
+                  }
+                }
+              }
+
+              const decodeClipFrameForTransition = async (
+                clip: (typeof tracks)[0]["clips"][0],
+              ): Promise<ImageBitmap | null> => {
+                const resources = playbackResourcesRef.current.get(clip.id);
+                if (!resources) return null;
+                const speedEngine = getSpeedEngine();
+                const localTime = currentPlayhead - clip.startTime;
+                const adjustedLocalTime =
+                  speedEngine.getSourceTimeAtPlaybackTime(clip.id, localTime);
+                const sourceTime = Math.max(
+                  clip.inPoint,
+                  Math.min(
+                    clip.outPoint,
+                    (clip.inPoint || 0) + adjustedLocalTime,
+                  ),
+                );
+                try {
+                  const result = await (
+                    resources.sink as {
+                      getCanvas: (time: number) => Promise<{
+                        canvas: HTMLCanvasElement | OffscreenCanvas;
+                      } | null>;
+                    }
+                  ).getCanvas(sourceTime);
+                  if (!result?.canvas) return null;
+                  return await createImageBitmap(result.canvas);
+                } catch (error) {
+                  console.warn(
+                    `[Preview] Transition decode failed for clip ${clip.id}:`,
+                    error,
+                  );
+                  return null;
+                }
+              };
+
+              const [outgoing, incoming] = await Promise.all([
+                decodeClipFrameForTransition(aLookup.clip),
+                decodeClipFrameForTransition(bLookup.clip),
+              ]);
+
+              if (outgoing && incoming) {
+                try {
+                  const blended = await renderTransitionFrame(
+                    transitionInfoMulti,
+                    outgoing,
+                    incoming,
+                  );
+
+                  ctx.fillStyle = "#000000";
+                  ctx.fillRect(0, 0, canvas.width, canvas.height);
+                  ctx.drawImage(blended, 0, 0, canvas.width, canvas.height);
+
+                  for (const shapeClip of activeShapeClips) {
+                    renderShapeClipToCanvas(
+                      ctx,
+                      shapeClip,
+                      canvas.width,
+                      canvas.height,
+                      currentPlayhead,
+                    );
+                  }
+                  for (const textClip of activeTextClips) {
+                    renderTextClipToCanvas(
+                      ctx,
+                      textClip,
+                      canvas.width,
+                      canvas.height,
+                      currentPlayhead,
+                    );
+                  }
+                  const activeSubtitlesTr = getActiveSubtitles(
+                    allSubtitlesRef.current,
+                    currentPlayhead,
+                  );
+                  for (const subtitle of activeSubtitlesTr) {
+                    renderSubtitleToCanvas(
+                      ctx,
+                      subtitle,
+                      canvas.width,
+                      canvas.height,
+                      currentPlayhead,
+                    );
+                  }
+
+                  mainCtx.drawImage(offscreenCanvasRef.current!, 0, 0);
+                  blended.close();
+                  outgoing.close();
+                  incoming.close();
+
+                  frameCount++;
+                  masterClock.reportVideoTime(currentPlayhead);
+                  const nowTr = performance.now();
+                  if (
+                    nowTr - lastPlayheadUpdateRef.current >=
+                    PLAYHEAD_UPDATE_THROTTLE_MS
+                  ) {
+                    lastPlayheadUpdateRef.current = nowTr;
+                    setPlayheadPosition(currentPlayhead);
+                  }
+                  const elapsedTr = nowTr - lastFrameTimestamp;
+                  const targetTimeTr = frameDuration / rateRef.current;
+                  const delayTr = Math.max(0, targetTimeTr - elapsedTr);
+                  lastFrameTimestamp = nowTr;
+                  isProcessingFrame = false;
+                  if (isActive) {
+                    if (delayTr > 0) {
+                      setTimeout(() => {
+                        if (isActive) {
+                          animationRef.current = requestAnimationFrame(
+                            processMultiTrackFrame,
+                          );
+                        }
+                      }, delayTr);
+                    } else {
+                      animationRef.current = requestAnimationFrame(
+                        processMultiTrackFrame,
+                      );
+                    }
+                  }
+                  return;
+                } catch (error) {
+                  console.warn(
+                    "[Preview] Transition render failed, falling back to normal compositing:",
+                    error,
+                  );
+                  outgoing.close();
+                  incoming.close();
+                }
+              } else {
+                outgoing?.close();
+                incoming?.close();
+              }
+            }
+          }
+
           const activeClipIds = new Set(activeClips.map((c) => c.clip.id));
           for (const [clipId, resources] of playbackResourcesRef.current) {
             if (!activeClipIds.has(clipId)) {
@@ -3705,14 +3905,6 @@ export const Preview: React.FC = () => {
 
           const sortedClips = [...activeClips].sort(
             (a, b) => b.trackIndex - a.trackIndex,
-          );
-          const activeShapeClips = getActiveShapeClips(
-            allShapeClipsRef.current,
-            currentPlayhead,
-          );
-          const activeTextClips = getActiveTextClips(
-            allTextClipsRef.current,
-            currentPlayhead,
           );
           const activeTextNeedsSubject = hasBehindSubjectText(activeTextClips);
           const useGPUFrames =

--- a/apps/web/src/components/editor/inspector/AdjustmentLayerSection.tsx
+++ b/apps/web/src/components/editor/inspector/AdjustmentLayerSection.tsx
@@ -12,6 +12,11 @@ import {
   Copy,
 } from "lucide-react";
 import { Slider } from "@openreel/ui";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@openreel/ui/components/popover";
 import { useEngineStore } from "../../../stores/engine-store";
 import { useProjectStore } from "../../../stores/project-store";
 import type { AdjustmentLayer, BlendMode, Effect } from "@openreel/core";
@@ -323,35 +328,40 @@ export const AdjustmentLayerSection: React.FC<AdjustmentLayerSectionProps> = ({
                 <Palette size={10} />
                 Blend Mode
               </label>
-              <div className="relative">
-                <button
-                  onClick={() => setShowBlendModes(!showBlendModes)}
-                  className="w-full flex items-center justify-between p-2 bg-background-secondary rounded text-[10px] text-text-primary hover:bg-background-tertiary transition-colors"
+              <Popover open={showBlendModes} onOpenChange={setShowBlendModes}>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className="w-full flex items-center justify-between p-2 bg-background-secondary rounded text-[10px] text-text-primary hover:bg-background-tertiary transition-colors"
+                  >
+                    <span>
+                      {BLEND_MODES.find((m) => m.id === layer.blendMode)?.name ||
+                        "Normal"}
+                    </span>
+                    <ChevronDown size={10} />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="start"
+                  sideOffset={4}
+                  className="w-[var(--radix-popover-trigger-width)] min-w-[180px] p-0 bg-background-secondary border-border max-h-48 overflow-y-auto"
                 >
-                  <span>
-                    {BLEND_MODES.find((m) => m.id === layer.blendMode)?.name ||
-                      "Normal"}
-                  </span>
-                  <ChevronDown size={10} />
-                </button>
-                {showBlendModes && (
-                  <div className="absolute top-full left-0 right-0 mt-1 bg-background-secondary border border-border rounded-lg shadow-lg z-10 max-h-48 overflow-y-auto">
-                    {BLEND_MODES.map((mode) => (
-                      <button
-                        key={mode.id}
-                        onClick={() => handleBlendModeChange(layer.id, mode.id)}
-                        className={`w-full text-left px-3 py-1.5 text-[10px] hover:bg-background-tertiary transition-colors ${
-                          layer.blendMode === mode.id
-                            ? "text-indigo-400 bg-indigo-500/10"
-                            : "text-text-secondary"
-                        }`}
-                      >
-                        {mode.name}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+                  {BLEND_MODES.map((mode) => (
+                    <button
+                      key={mode.id}
+                      type="button"
+                      onClick={() => handleBlendModeChange(layer.id, mode.id)}
+                      className={`w-full text-left px-3 py-1.5 text-[10px] hover:bg-background-tertiary transition-colors ${
+                        layer.blendMode === mode.id
+                          ? "text-indigo-400 bg-indigo-500/10"
+                          : "text-text-secondary"
+                      }`}
+                    >
+                      {mode.name}
+                    </button>
+                  ))}
+                </PopoverContent>
+              </Popover>
             </div>
 
             <div className="space-y-1.5">

--- a/apps/web/src/components/editor/inspector/KeyframesSection.tsx
+++ b/apps/web/src/components/editor/inspector/KeyframesSection.tsx
@@ -7,6 +7,11 @@ import {
   Diamond,
   DiamondIcon,
 } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@openreel/ui/components/popover";
 import { useProjectStore } from "../../../stores/project-store";
 import { useTimelineStore } from "../../../stores/timeline-store";
 import { useEngineStore } from "../../../stores/engine-store";
@@ -160,62 +165,61 @@ const PropertySelector: React.FC<{
     : "Select Property";
 
   return (
-    <div className="relative">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center justify-between px-3 py-2 bg-background-tertiary border border-border rounded-lg text-[10px] text-text-primary hover:border-text-secondary transition-colors"
-      >
-        <span>{selectedLabel}</span>
-        <ChevronDown
-          size={12}
-          className={`transition-transform ${isOpen ? "rotate-180" : ""}`}
-        />
-      </button>
-      {isOpen && (
-        <>
-          <div
-            className="fixed inset-0 z-10"
-            onClick={() => setIsOpen(false)}
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="w-full flex items-center justify-between px-3 py-2 bg-background-tertiary border border-border rounded-lg text-[10px] text-text-primary hover:border-text-secondary transition-colors"
+        >
+          <span>{selectedLabel}</span>
+          <ChevronDown
+            size={12}
+            className={`transition-transform ${isOpen ? "rotate-180" : ""}`}
           />
-          <div className="absolute top-full left-0 right-0 mt-1 bg-background-secondary border border-border rounded-lg shadow-lg z-20 max-h-64 overflow-y-auto">
-            {categories.map((category) => (
-              <div key={category}>
-                <div className="px-3 py-1.5 text-[9px] font-medium text-text-muted uppercase tracking-wider bg-background-tertiary">
-                  {category}
-                </div>
-                {ANIMATABLE_PROPERTIES.filter(
-                  (p) => p.category === category,
-                ).map((prop) => {
-                  const hasKeyframes = existingProperties.includes(prop.id);
-                  return (
-                    <button
-                      key={prop.id}
-                      onClick={() => {
-                        onSelect(prop.id);
-                        setIsOpen(false);
-                      }}
-                      className={`w-full px-3 py-2 text-left text-[10px] flex items-center justify-between hover:bg-background-tertiary transition-colors ${
-                        selectedProperty === prop.id
-                          ? "bg-primary/10 text-primary"
-                          : "text-text-primary"
-                      }`}
-                    >
-                      <span>{prop.label}</span>
-                      {hasKeyframes && (
-                        <Diamond
-                          size={10}
-                          className="text-primary fill-primary"
-                        />
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
-            ))}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={4}
+        className="w-[var(--radix-popover-trigger-width)] min-w-[200px] p-0 bg-background-secondary border-border max-h-64 overflow-y-auto"
+      >
+        {categories.map((category) => (
+          <div key={category}>
+            <div className="px-3 py-1.5 text-[9px] font-medium text-text-muted uppercase tracking-wider bg-background-tertiary">
+              {category}
+            </div>
+            {ANIMATABLE_PROPERTIES.filter(
+              (p) => p.category === category,
+            ).map((prop) => {
+              const hasKeyframes = existingProperties.includes(prop.id);
+              return (
+                <button
+                  key={prop.id}
+                  type="button"
+                  onClick={() => {
+                    onSelect(prop.id);
+                    setIsOpen(false);
+                  }}
+                  className={`w-full px-3 py-2 text-left text-[10px] flex items-center justify-between hover:bg-background-tertiary transition-colors ${
+                    selectedProperty === prop.id
+                      ? "bg-primary/10 text-primary"
+                      : "text-text-primary"
+                  }`}
+                >
+                  <span>{prop.label}</span>
+                  {hasKeyframes && (
+                    <Diamond
+                      size={10}
+                      className="text-primary fill-primary"
+                    />
+                  )}
+                </button>
+              );
+            })}
           </div>
-        </>
-      )}
-    </div>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 };
 
@@ -270,49 +274,48 @@ const EasingSelector: React.FC<{
   const currentLabel = formatEasingLabel(value);
 
   return (
-    <div className="relative">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1.5 px-2 py-1 bg-background-tertiary border border-border rounded text-[9px] text-text-secondary hover:text-text-primary hover:border-primary/50 transition-colors"
-        title={`Easing: ${currentLabel}`}
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 px-2 py-1 bg-background-tertiary border border-border rounded text-[9px] text-text-secondary hover:text-text-primary hover:border-primary/50 transition-colors"
+          title={`Easing: ${currentLabel}`}
+        >
+          <EasingCurvePreview easing={value} size={14} />
+          <span>{currentLabel}</span>
+          <ChevronDown size={10} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={4}
+        className="min-w-[180px] w-auto p-0 bg-background-secondary border-border max-h-64 overflow-y-auto"
       >
-        <EasingCurvePreview easing={value} size={14} />
-        <span>{currentLabel}</span>
-        <ChevronDown size={10} />
-      </button>
-      {isOpen && (
-        <>
-          <div
-            className="fixed inset-0 z-10"
-            onClick={() => setIsOpen(false)}
-          />
-          <div className="absolute top-full right-0 mt-1 bg-background-secondary border border-border rounded-lg shadow-lg z-20 min-w-[160px] max-h-64 overflow-y-auto">
-            {EASING_CATEGORIES.map((category) => (
-              <div key={category.name}>
-                <div className="px-3 py-1 text-[8px] font-medium text-text-muted uppercase tracking-wider bg-background-tertiary sticky top-0">
-                  {category.name}
-                </div>
-                {category.easings.map((easing) => (
-                  <button
-                    key={easing}
-                    onClick={() => {
-                      onChange(easing);
-                      setIsOpen(false);
-                    }}
-                    className={`w-full px-3 py-1.5 text-left text-[10px] hover:bg-background-tertiary transition-colors flex items-center gap-2 ${
-                      value === easing ? "text-primary" : "text-text-primary"
-                    }`}
-                  >
-                    <EasingCurvePreview easing={easing} size={14} />
-                    {formatEasingLabel(easing)}
-                  </button>
-                ))}
-              </div>
+        {EASING_CATEGORIES.map((category) => (
+          <div key={category.name}>
+            <div className="px-3 py-1 text-[8px] font-medium text-text-muted uppercase tracking-wider bg-background-tertiary sticky top-0">
+              {category.name}
+            </div>
+            {category.easings.map((easing) => (
+              <button
+                key={easing}
+                type="button"
+                onClick={() => {
+                  onChange(easing);
+                  setIsOpen(false);
+                }}
+                className={`w-full px-3 py-1.5 text-left text-[10px] hover:bg-background-tertiary transition-colors flex items-center gap-2 ${
+                  value === easing ? "text-primary" : "text-text-primary"
+                }`}
+              >
+                <EasingCurvePreview easing={easing} size={14} />
+                {formatEasingLabel(easing)}
+              </button>
             ))}
           </div>
-        </>
-      )}
-    </div>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/packages/core/src/video/transition-engine.test.ts
+++ b/packages/core/src/video/transition-engine.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { TransitionEngine } from "./transition-engine";
+import type { Clip } from "../types/timeline";
+
+function makeClip(overrides: Partial<Clip> = {}): Clip {
+  return {
+    id: "clip-1",
+    mediaId: "media-1",
+    trackId: "track-1",
+    startTime: 0,
+    duration: 5,
+    inPoint: 0,
+    outPoint: 5,
+    effects: [],
+    audioEffects: [],
+    transform: {
+      position: { x: 0, y: 0 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+      opacity: 1,
+      anchorPoint: { x: 0, y: 0 },
+    },
+    volume: 1,
+    ...overrides,
+  } as Clip;
+}
+
+describe("TransitionEngine", () => {
+  let engine: TransitionEngine;
+
+  beforeEach(() => {
+    engine = new TransitionEngine({ width: 1920, height: 1080 });
+  });
+
+  describe("validateTransition", () => {
+    it("accepts adjacent clips on the same track", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", startTime: 5, duration: 5 });
+      const result = engine.validateTransition(a, b, 1);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects non-adjacent clips", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", startTime: 6, duration: 5 });
+      const result = engine.validateTransition(a, b, 1);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects clips on different tracks", () => {
+      const a = makeClip({ id: "a", trackId: "t1", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", trackId: "t2", startTime: 5, duration: 5 });
+      const result = engine.validateTransition(a, b, 1);
+      expect(result.valid).toBe(false);
+    });
+
+    it("warns when duration exceeds available range", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 1 });
+      const b = makeClip({ id: "b", startTime: 1, duration: 1 });
+      const result = engine.validateTransition(a, b, 10);
+      expect(result.valid).toBe(true);
+      expect(result.warning).toBeDefined();
+      expect(result.maxDuration).toBe(2);
+    });
+
+    it("rejects zero or negative durations", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", startTime: 5, duration: 5 });
+      expect(engine.validateTransition(a, b, 0).valid).toBe(false);
+      expect(engine.validateTransition(a, b, -1).valid).toBe(false);
+    });
+  });
+
+  describe("isTimeInTransition / calculateTransitionProgress", () => {
+    const a = makeClip({ id: "a", startTime: 0, duration: 5 });
+    const transition = {
+      id: "t",
+      clipAId: "a",
+      clipBId: "b",
+      type: "crossfade" as const,
+      duration: 1,
+      params: {},
+    };
+
+    it("centers the transition on the cut point", () => {
+      // Cut at t=5, duration=1, window should be [4.5, 5.5]
+      expect(engine.isTimeInTransition(transition, a, 4.4)).toBe(false);
+      expect(engine.isTimeInTransition(transition, a, 4.5)).toBe(true);
+      expect(engine.isTimeInTransition(transition, a, 5.0)).toBe(true);
+      expect(engine.isTimeInTransition(transition, a, 5.5)).toBe(true);
+      expect(engine.isTimeInTransition(transition, a, 5.6)).toBe(false);
+    });
+
+    it("reports 0 progress at start and 1 at end", () => {
+      expect(engine.calculateTransitionProgress(transition, a, 4.5)).toBe(0);
+      expect(engine.calculateTransitionProgress(transition, a, 5.0)).toBeCloseTo(
+        0.5,
+        5,
+      );
+      expect(engine.calculateTransitionProgress(transition, a, 5.5)).toBe(1);
+    });
+  });
+
+  describe("createTransition", () => {
+    it("returns a transition with both clip IDs and default params", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", startTime: 5, duration: 5 });
+      const t = engine.createTransition(a, b, "crossfade", 1);
+      expect(t).not.toBeNull();
+      expect(t!.clipAId).toBe("a");
+      expect(t!.clipBId).toBe("b");
+      expect(t!.type).toBe("crossfade");
+      expect(t!.duration).toBe(1);
+      expect(t!.params).toEqual({ curve: "ease" });
+    });
+
+    it("clamps to maxDuration when requested duration is too long", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 1 });
+      const b = makeClip({ id: "b", startTime: 1, duration: 1 });
+      const t = engine.createTransition(a, b, "crossfade", 10);
+      expect(t!.duration).toBe(2);
+    });
+  });
+
+  describe("areClipsAdjacent", () => {
+    it("returns true for clips with negligible gap", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", startTime: 5.0005, duration: 5 });
+      expect(engine.areClipsAdjacent(a, b)).toBe(true);
+    });
+
+    it("returns false for clips with a real gap", () => {
+      const a = makeClip({ id: "a", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", startTime: 5.1, duration: 5 });
+      expect(engine.areClipsAdjacent(a, b)).toBe(false);
+    });
+
+    it("returns false for clips on different tracks", () => {
+      const a = makeClip({ id: "a", trackId: "t1", startTime: 0, duration: 5 });
+      const b = makeClip({ id: "b", trackId: "t2", startTime: 5, duration: 5 });
+      expect(engine.areClipsAdjacent(a, b)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/video/transition-engine.ts
+++ b/packages/core/src/video/transition-engine.ts
@@ -430,25 +430,12 @@ export class TransitionEngine {
       };
     }
 
-    // Handle frames available beyond the visible cut point. For a
-    // center-on-cut transition we need handles on clipA's TAIL (frames after
-    // outPoint) and clipB's HEAD (frames before inPoint) — half the duration
-    // on each side. Without source-media metadata we can only verify the
-    // leading handle of clipB; for clipA we conservatively assume zero tail
-    // handles, falling back to the visible range.
-    const clipAVisibleHandle = clipA.duration; // can borrow from within visible range as a fallback
-    const clipBLeadingHandle = clipB.inPoint;
-    const clipBVisibleHandle = clipB.duration;
-
-    const maxDuration = Math.min(
-      clipA.duration,
-      clipB.duration,
-      // tail of clipA (visible only) + leading source-handle of clipB allows
-      // half the duration on each side
-      (clipAVisibleHandle + clipBLeadingHandle) * 2,
-      clipAVisibleHandle * 2,
-      (clipBLeadingHandle + clipBVisibleHandle) * 2,
-    );
+    // For a center-on-cut transition the window extends ±duration/2 around
+    // the cut, so duration cannot exceed twice either clip's visible length.
+    // We can't validate source-media handles without media metadata, so we
+    // bound by the visible ranges and let the decoder clamp to edge frames
+    // when the transition extends past a clip's range.
+    const maxDuration = Math.min(clipA.duration, clipB.duration) * 2;
 
     if (duration > maxDuration) {
       return {

--- a/packages/core/src/video/transition-engine.ts
+++ b/packages/core/src/video/transition-engine.ts
@@ -595,6 +595,10 @@ export class TransitionEngine {
     return currentTime >= transitionStart && currentTime <= transitionEnd;
   }
 
+  getEngineDimensions(): { width: number; height: number } {
+    return { width: this.width, height: this.height };
+  }
+
   resize(width: number, height: number): void {
     this.width = width;
     this.height = height;

--- a/packages/core/src/video/transition-engine.ts
+++ b/packages/core/src/video/transition-engine.ts
@@ -430,18 +430,24 @@ export class TransitionEngine {
       };
     }
 
-    const clipAHandleFrames = clipA.outPoint - clipA.duration; // Media after visible end
-    const clipBHandleFrames = clipB.inPoint; // Media before visible start
+    // Handle frames available beyond the visible cut point. For a
+    // center-on-cut transition we need handles on clipA's TAIL (frames after
+    // outPoint) and clipB's HEAD (frames before inPoint) — half the duration
+    // on each side. Without source-media metadata we can only verify the
+    // leading handle of clipB; for clipA we conservatively assume zero tail
+    // handles, falling back to the visible range.
+    const clipAVisibleHandle = clipA.duration; // can borrow from within visible range as a fallback
+    const clipBLeadingHandle = clipB.inPoint;
+    const clipBVisibleHandle = clipB.duration;
 
-    const maxFromClipA = clipA.duration + clipAHandleFrames;
-    const maxFromClipB = clipB.duration + clipBHandleFrames;
-
-    // Maximum transition duration is limited by available handles
     const maxDuration = Math.min(
       clipA.duration,
       clipB.duration,
-      maxFromClipA,
-      maxFromClipB,
+      // tail of clipA (visible only) + leading source-handle of clipB allows
+      // half the duration on each side
+      (clipAVisibleHandle + clipBLeadingHandle) * 2,
+      clipAVisibleHandle * 2,
+      (clipBLeadingHandle + clipBVisibleHandle) * 2,
     );
 
     if (duration > maxDuration) {

--- a/packages/core/src/video/video-engine.ts
+++ b/packages/core/src/video/video-engine.ts
@@ -1324,41 +1324,63 @@ export class VideoEngine {
       return baseEffects;
     }
 
-    const effectPropertyMap: Record<string, string> = {
-      "effect.brightness": "brightness",
-      "effect.contrast": "contrast",
-      "effect.saturation": "saturation",
-      "effect.blur": "blur",
-    };
+    // Each entry maps a keyframe property → effect type and the actual
+    // param key the renderer reads (see EFFECT_DEFINITIONS in types/effects.ts).
+    const effectPropertyMap: Array<{
+      keyframeProp: string;
+      effectType: string;
+      paramKey: string;
+    }> = [
+      { keyframeProp: "effect.brightness", effectType: "brightness", paramKey: "value" },
+      { keyframeProp: "effect.contrast", effectType: "contrast", paramKey: "value" },
+      { keyframeProp: "effect.saturation", effectType: "saturation", paramKey: "value" },
+      { keyframeProp: "effect.blur", effectType: "blur", paramKey: "radius" },
+    ];
 
-    const animatedParams: Record<string, number> = {};
+    const animatedByType = new Map<string, { paramKey: string; value: number }>();
 
-    for (const [keyframeProp, paramName] of Object.entries(effectPropertyMap)) {
+    for (const { keyframeProp, effectType, paramKey } of effectPropertyMap) {
       const effectKfs = keyframeEngine.getKeyframesForProperty(
         keyframes,
         keyframeProp,
       );
-      if (effectKfs.length > 0) {
-        const result = keyframeEngine.getValueAtTime(effectKfs, localTime);
-        if (typeof result.value === "number") {
-          animatedParams[paramName] = result.value;
-        }
+      if (effectKfs.length === 0) continue;
+      const result = keyframeEngine.getValueAtTime(effectKfs, localTime);
+      if (typeof result.value === "number") {
+        animatedByType.set(effectType, { paramKey, value: result.value });
       }
     }
 
-    if (Object.keys(animatedParams).length === 0) {
+    if (animatedByType.size === 0) {
       return baseEffects;
     }
 
-    return baseEffects.map((effect) => {
-      const updatedParams = { ...effect.params };
-      for (const [paramName, value] of Object.entries(animatedParams)) {
-        if (effect.type === paramName || paramName in updatedParams) {
-          updatedParams[paramName] = value;
-        }
-      }
-      return { ...effect, params: updatedParams };
+    // Patch existing effects with interpolated values.
+    const seen = new Set<string>();
+    const patched = baseEffects.map((effect) => {
+      const animated = animatedByType.get(effect.type);
+      if (!animated) return effect;
+      seen.add(effect.type);
+      return {
+        ...effect,
+        params: { ...effect.params, [animated.paramKey]: animated.value },
+      };
     });
+
+    // Synthesize effects that have keyframes but aren't on the clip yet,
+    // so users can animate brightness/contrast/etc. without first adding the
+    // effect manually.
+    for (const [effectType, { paramKey, value }] of animatedByType) {
+      if (seen.has(effectType)) continue;
+      patched.push({
+        id: `kf-synth-${clip.id}-${effectType}`,
+        type: effectType as Effect["type"],
+        enabled: true,
+        params: { [paramKey]: value },
+      } as Effect);
+    }
+
+    return patched;
   }
 
   private getAnimatedTransform(clip: Clip, localTime: number): Transform {

--- a/packages/core/src/video/video-engine.ts
+++ b/packages/core/src/video/video-engine.ts
@@ -12,6 +12,8 @@ import type { ShapeClip, EmphasisAnimation } from "../graphics/types";
 import { titleEngine } from "../text/title-engine";
 import { graphicsEngine } from "../graphics/graphics-engine";
 import { VideoEffectsEngine } from "./video-effects-engine";
+import { TransitionEngine } from "./transition-engine";
+import type { Transition } from "../types/timeline";
 import { getMediaEngine } from "../media/mediabunny-engine";
 import type {
   RenderedFrame,
@@ -101,6 +103,7 @@ export class VideoEngine {
   private gpuCompositor: GPUCompositor | null = null;
   private gpuRenderer: Renderer | null = null;
   private effectsEngine: VideoEffectsEngine | null = null;
+  private transitionEngine: TransitionEngine | null = null;
   private lastExportTime: number = -1;
   private exportFrameRate: number = 30;
   exportMode: boolean = false;
@@ -578,8 +581,23 @@ export class VideoEngine {
 
     for (const { track } of allRenderableTracks) {
       if (track.type === "video" || track.type === "image") {
+        // If a clip-to-clip transition is active in this track at `time`,
+        // decode both participating clips, blend them, and draw the result.
+        // The clip IDs that were rendered as part of the transition are
+        // returned so the normal per-clip loop can skip them.
+        const renderedTransitionClips = await this.renderActiveTransition(
+          track,
+          time,
+          mediaLibrary,
+          settings,
+          width,
+          height,
+          ctx,
+        );
+
         const clips = this.getClipsAtTime(track, time);
         for (const clip of clips) {
+          if (renderedTransitionClips.has(clip.id)) continue;
           const clipInfo = this.createClipRenderInfo(clip, time);
           const mediaItem = mediaLibrary.items.find(
             (m) => m.id === clipInfo.mediaId,
@@ -1292,6 +1310,168 @@ export class VideoEngine {
       const clipEnd = clip.startTime + clip.duration;
       return time >= clip.startTime && time < clipEnd;
     });
+  }
+
+  // Find a transition on `track` whose centered-on-cut window contains `time`.
+  private findActiveTransition(
+    track: Track,
+    time: number,
+  ): { transition: Transition; clipA: Clip; clipB: Clip; progress: number } | null {
+    const transitions = track.transitions || [];
+    for (const transition of transitions) {
+      const clipA = track.clips.find((c) => c.id === transition.clipAId);
+      const clipB = track.clips.find((c) => c.id === transition.clipBId);
+      if (!clipA || !clipB) continue;
+
+      const cut = clipA.startTime + clipA.duration;
+      const start = cut - transition.duration / 2;
+      const end = cut + transition.duration / 2;
+      if (time < start || time > end) continue;
+
+      const progress = transition.duration > 0
+        ? Math.max(0, Math.min(1, (time - start) / transition.duration))
+        : 0;
+      return { transition, clipA, clipB, progress };
+    }
+    return null;
+  }
+
+  // Decode a single video/image clip frame at the given absolute project
+  // `time` and return it as an ImageBitmap sized to (width, height). Returns
+  // null when decoding fails or the media is missing.
+  private async decodeClipBitmap(
+    clip: Clip,
+    mediaItem: MediaItem,
+    time: number,
+    width: number,
+    height: number,
+  ): Promise<ImageBitmap | null> {
+    if (!mediaItem.blob) return null;
+
+    if (mediaItem.type === "image") {
+      try {
+        if (isAnimatedGif(mediaItem.blob)) {
+          let gifCache = this.gifFrameCache.get(mediaItem.id);
+          if (!gifCache) {
+            const created = await createGifFrameCache(mediaItem.blob);
+            if (created) {
+              this.gifFrameCache.set(mediaItem.id, created);
+              gifCache = created;
+            }
+          }
+          if (gifCache && gifCache.frames.length > 0) {
+            const clipLocalTime = time - clip.startTime;
+            const idx = getGifFrameAtTime(gifCache, clipLocalTime * 1000);
+            return gifCache.frames[idx];
+          }
+        }
+        const cached = this.staticImageCache.get(mediaItem.id);
+        if (cached) return cached;
+        const bitmap = await createImageBitmap(mediaItem.blob);
+        this.staticImageCache.set(mediaItem.id, bitmap);
+        return bitmap;
+      } catch (error) {
+        console.warn(
+          `[VideoEngine] decodeClipBitmap (image) failed for ${mediaItem.id}:`,
+          error,
+        );
+        return null;
+      }
+    }
+
+    const speedEngine = getSpeedEngine();
+    const localTime = time - clip.startTime;
+    const sourceTime = Math.max(
+      clip.inPoint,
+      Math.min(
+        clip.outPoint,
+        clip.inPoint + speedEngine.getSourceTimeAtPlaybackTime(clip.id, localTime),
+      ),
+    );
+
+    let bitmap = await this.decodeFrameWithMediaBunny(
+      mediaItem.blob,
+      sourceTime,
+      width,
+      height,
+      mediaItem.id,
+    );
+    if (!bitmap) {
+      bitmap = await this.decodeFrameWithVideoElement(
+        mediaItem.id,
+        mediaItem.blob,
+        sourceTime,
+        width,
+        height,
+      );
+    }
+    return bitmap;
+  }
+
+  private async renderActiveTransition(
+    track: Track,
+    time: number,
+    mediaLibrary: Project["mediaLibrary"],
+    _settings: Project["settings"],
+    width: number,
+    height: number,
+    ctx: OffscreenCanvasRenderingContext2D,
+  ): Promise<Set<string>> {
+    const rendered = new Set<string>();
+
+    const active = this.findActiveTransition(track, time);
+    if (!active) return rendered;
+
+    const { transition, clipA, clipB, progress } = active;
+
+    const mediaA = mediaLibrary.items.find((m) => m.id === clipA.mediaId);
+    const mediaB = mediaLibrary.items.find((m) => m.id === clipB.mediaId);
+    if (!mediaA?.blob || !mediaB?.blob) return rendered;
+
+    try {
+      const [bitmapA, bitmapB] = await Promise.all([
+        this.decodeClipBitmap(clipA, mediaA, time, width, height),
+        this.decodeClipBitmap(clipB, mediaB, time, width, height),
+      ]);
+      if (!bitmapA || !bitmapB) {
+        if (bitmapA && !this.staticImageCache.has(mediaA.id)) bitmapA.close();
+        if (bitmapB && !this.staticImageCache.has(mediaB.id)) bitmapB.close();
+        return rendered;
+      }
+
+      if (
+        !this.transitionEngine ||
+        this.transitionEngine.getEngineDimensions().width !== width ||
+        this.transitionEngine.getEngineDimensions().height !== height
+      ) {
+        this.transitionEngine = new TransitionEngine({ width, height });
+      }
+
+      const result = await this.transitionEngine.renderTransition(
+        bitmapA,
+        bitmapB,
+        transition,
+        progress,
+      );
+
+      if (result.frame) {
+        ctx.drawImage(result.frame, 0, 0, width, height);
+        result.frame.close();
+      }
+
+      if (mediaA.type !== "image") bitmapA.close();
+      if (mediaB.type !== "image") bitmapB.close();
+
+      rendered.add(clipA.id);
+      rendered.add(clipB.id);
+    } catch (error) {
+      console.warn(
+        `[VideoEngine] transition render failed (clipA=${clipA.id} clipB=${clipB.id}):`,
+        error,
+      );
+    }
+
+    return rendered;
   }
 
   private createClipRenderInfo(clip: Clip, time: number): VideoClipRenderInfo {

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -84,7 +84,7 @@ const SelectContent = React.forwardRef<
         exit={{ opacity: 0, scale: 0.96, y: -4 }}
         transition={{ type: "spring", stiffness: 500, damping: 30 }}
         className={cn(
-          "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md origin-[--radix-select-content-transform-origin]",
+          "relative z-[9999] max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md origin-[--radix-select-content-transform-origin]",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className


### PR DESCRIPTION
## Summary

Three user-reported issues, one branch:

### 1. Clip-to-clip transitions silently bypassed (the big one)
- **Preview playback path**: `getTransitionAtTime` was only called inside `renderFrameDirectly` (the scrub/pause path). Both playback paths (`drawFrame` inside `startNativeVideoPlayback` and `processMultiTrackFrame`) skipped transitions entirely, so the user got a hard cut the moment they hit play.
- **Export path**: `VideoEngine.renderFrame` had zero references to transitions. Exported videos showed hard cuts regardless of what played in preview.

**Fix:**
- `canUseNativeVideoPlayback` now returns false whenever any transition's window extends into the remaining playback range — the native `<video>`-element path can't blend two clips.
- `processMultiTrackFrame` checks `getTransitionAtTime` after computing `activeClips`. When a transition is active it lazily inits MediaBunny resources for both clips, decodes them, blends via the existing `renderTransitionFrame`, draws the result, then layers shape/text/subtitle overlays.
- `VideoEngine` now owns a lazy `TransitionEngine` instance plus three new helpers (`findActiveTransition`, `decodeClipBitmap`, `renderActiveTransition`). `renderFrame` calls them per video/image track before the normal per-clip loop and skips any clip whose ID was consumed by a transition.
- Simplified `validateTransition.maxDuration` math — the old `outPoint - duration` always equalled `inPoint` (leading handle, not trailing).

### 2. Keyframe effect interpolation written to the wrong key
`video-engine.getAnimatedEffects` wrote interpolated values to `params.brightness`, `params.contrast`, etc., but every renderer reads `params.value` (and `params.radius` for blur). Animated effect keyframes were stored, interpolated, then dropped. Fixed the mapping and the engine now synthesizes the effect when a keyframe exists for an effect type not yet on the clip.

### 3. Selector dropdowns hidden behind editor panels
- `SelectContent` was `z-50`; sibling editor panels (Timeline header `z-[100]`, floating panels, tour overlays) sit higher, so the dropdown rendered behind them. Raised to `z-[9999]` to match `Popover`/`DropdownMenu`.
- `KeyframesSection`'s property/easing pickers and `AdjustmentLayerSection`'s blend-mode picker were hand-rolled inline dropdowns at `z-20` with a `fixed inset-0 z-10` click-trap — clipped by the inspector's `overflow-y-auto` and stealing clicks from the rest of the editor. Replaced with Radix `Popover` so they auto-portal and only intercept clicks where they should.

## Test plan
- [x] Core test suite: 188/188 passing (added 12 new transition-engine tests)
- [x] Web typecheck + test run: same single pre-existing failure (`project-store.test.ts:851` track-ordering — present on `main` before this branch)
- [x] Full `pnpm typecheck` clean
- [ ] Manual: apply a clip-to-clip crossfade, hit play, verify blend
- [ ] Manual: export the same project, verify the rendered MP4 contains the transition
- [ ] Manual: animate brightness via a keyframe — verify it changes during playback
- [ ] Manual: open Property/Easing/Blend-mode pickers — verify they appear in front and don't trap clicks