### PR TITLE
fix(proxy): Allow production Pages domain in API proxy CORS allow-list

### DIFF
--- a/apps/web/functions/api/proxy/[[catchall]].ts
+++ b/apps/web/functions/api/proxy/[[catchall]].ts
@@ -41,6 +41,7 @@ const SERVICE_CONFIG: Record<string, ServiceConfig> = {
 };
 
 const ALLOWED_ORIGINS = [
+  "https://openreel-eg5.pages.dev",
   "https://openreel.pages.dev",
   "https://openreel-preview.pages.dev",
   "http://localhost:5173",


### PR DESCRIPTION
## What

Add `https://openreel-eg5.pages.dev` to the `ALLOWED_ORIGINS` list in the API proxy Pages Function (`apps/web/functions/api/proxy/[[catchall]].ts`).

## Why

The proxy only whitelisted `openreel.pages.dev` and the preview domain. Browser calls from a deployed `*.pages.dev` origin that isn't on the list receive a mismatched `Access-Control-Allow-Origin` header and fail the browser CORS check, breaking the TTS/caption AI proxy features on that deployment.

## Testing

Deployed to Cloudflare Pages and verified the preflight:

- Preflight from `https://openreel-eg5.pages.dev` -> `access-control-allow-origin: https://openreel-eg5.pages.dev` (pass)
- Preflight from a disallowed origin -> falls back to first allowed origin (correctly fails CORS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)