### PR TITLE
fix(ui): remove 'Pro' branding text

### DIFF
--- a/apps/web/src/components/editor/AIGenTab.tsx
+++ b/apps/web/src/components/editor/AIGenTab.tsx
@@ -227,7 +227,7 @@ export const AIGenTab: React.FC = () => {
           />
         </FeatureSection>
 
-        <FeatureSection title="Pro Tools" icon={Video}>
+        <FeatureSection title="Tools" icon={Video}>
           <FeatureCard
             icon={Video}
             title="Multi-Camera Editing"

--- a/apps/web/src/components/editor/Toolbar.tsx
+++ b/apps/web/src/components/editor/Toolbar.tsx
@@ -785,7 +785,6 @@ export const Toolbar: React.FC = () => {
               className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[12px] font-medium text-fg-2 hover:bg-hover hover:text-fg transition-colors"
             >
               <Star size={14} />
-              <span>Pro</span>
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-56">
@@ -862,9 +861,6 @@ export const Toolbar: React.FC = () => {
                 <Upload size={13} />
                 <span>Export</span>
                 <ChevronDown size={12} className={`transition-transform ${isExportOpen ? "rotate-180" : ""}`} />
-                <span className="absolute -top-1.5 -right-1.5 bg-[oklch(0.78_0.14_80)] text-[oklch(0.2_0.05_80)] text-[8.5px] px-[5px] py-px rounded-full font-bold tracking-wider">
-                  Pro
-                </span>
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-72 p-0 rounded-xl bg-bg-1 border-border">

--- a/apps/web/src/components/welcome/TemplateCard.tsx
+++ b/apps/web/src/components/welcome/TemplateCard.tsx
@@ -130,7 +130,6 @@ export const TemplateCard: React.FC<TemplateCardProps> = ({
         {template.premium && (
           <div className="absolute top-2 right-2 px-2 py-0.5 bg-primary text-black text-[10px] font-semibold rounded-full flex items-center gap-1">
             <Crown size={10} />
-            Pro
           </div>
         )}
       </div>


### PR DESCRIPTION
Removes the user-facing **"Pro" text** from the UI while keeping all features/buttons intact (per request: "just remove the text 'pro', not the features").

## Changed
- **Toolbar** — the standalone `Pro` pill keeps its menu (theme/settings/recorder/tours) but drops the "Pro" label (now an icon-only trigger).
- **Toolbar** — removed the `Pro` badge on the Export button (Export unchanged).
- **TemplateCard** — premium templates keep their Crown badge; removed the "Pro" text.
- **AIGenTab** — "Pro Tools" section renamed to "Tools".

## Intentionally NOT changed (proper nouns / not openreel branding)
- `Flux 2 Pro` (third-party AI model name) in ModelPicker
- `Premiere Pro` / `Final Cut Pro` (keyboard-shortcut preset names for those editors)
- `Pro Tips` label in the motion-graphics tour (generic phrase)

Renaming those would corrupt real product names — flagging for a decision rather than changing them.

## Verification
- `pnpm --filter @openreel/web typecheck` ✅
- web lint ✅ 0 errors
- Verified in the running app: toolbar shows no "Pro" pill text and no "Pro" badge on Export.