### PR TITLE
fix(preview): ghosting when changing clip properties + scroll tab cleanups

### DIFF
--- a/apps/web/src/components/editor/AssetsPanel.tsx
+++ b/apps/web/src/components/editor/AssetsPanel.tsx
@@ -1529,19 +1529,19 @@ export const AssetsPanel: React.FC = () => {
         );
       case "ai":
         return (
-          <div className="flex min-h-0 flex-1 flex-col border-t border-border/70 bg-background-secondary content-area-fix">
+          <div className="flex min-h-0 flex-1 flex-col border-t border-border/70 bg-background-secondary">
             <AIGenTab />
           </div>
         );
       case "recipes":
         return (
-          <div className="flex min-h-0 flex-1 flex-col border-t border-border/70 bg-background-secondary content-area-fix">
+          <div className="flex min-h-0 flex-1 flex-col border-t border-border/70 bg-background-secondary">
             <RecipesTab />
           </div>
         );
       case "templates":
         return (
-          <div className="flex min-h-0 flex-1 flex-col border-t border-border/70 bg-background-secondary content-area-fix">
+          <div className="flex min-h-0 flex-1 flex-col border-t border-border/70 bg-background-secondary">
             <TemplatesTab />
           </div>
         );

--- a/apps/web/src/components/editor/Preview.tsx
+++ b/apps/web/src/components/editor/Preview.tsx
@@ -2650,8 +2650,13 @@ export const Preview: React.FC = () => {
 
       let hasRenderedFrame = false;
       let shouldClearCanvas = true;
-      const hadBackground = Boolean(lastGoodFrameRef.current);
       if (lastGoodFrameRef.current) {
+        // Anti-flicker placeholder ONLY: the previous composite is pasted so
+        // the canvas is never momentarily blank while frames decode, but it
+        // must never suppress the real clear/background fill below. When a
+        // clip's transform changes, fresh content is drawn over a cleared
+        // background — otherwise stale pixels from the previous composite
+        // survive around the new position (ghosting).
         ctx.drawImage(
           lastGoodFrameRef.current,
           0,
@@ -2659,7 +2664,6 @@ export const Preview: React.FC = () => {
           canvas.width,
           canvas.height,
         );
-        shouldClearCanvas = false;
       }
 
       const activeShapeClips = getActiveShapeClips(allShapeClips, time);
@@ -3198,9 +3202,13 @@ export const Preview: React.FC = () => {
         activeShapeClips.length > 0 ||
         activeTextClips.length > 0;
 
-      if (hadBackground && hasActiveContent && offscreenCanvasRef.current) {
+      if (hasActiveContent && lastGoodFrameRef.current) {
+        // Render-failure fallback: paint from the cached composite bitmap —
+        // never from the working offscreen buffer, which may hold stale or
+        // partially-drawn pixels. This keeps the previous frame as a stable
+        // placeholder instead of ghosting partial content.
         mainCtx.clearRect(0, 0, canvas.width, canvas.height);
-        mainCtx.drawImage(offscreenCanvasRef.current, 0, 0);
+        mainCtx.drawImage(lastGoodFrameRef.current, 0, 0);
         return true;
       }
 


### PR DESCRIPTION
## Bug fix: preview ghosting when changing clip properties

Re-implements the fix from PR #93 for the ghosting reported when changing a clip's transform (position/scale/rotation) in the Player: the canvas shows the old and new versions of the clip overlapping until play/scrub.

**Root cause (in today's main, `Preview.tsx` offline draw path):** the last-good-frame paste (`lastGoodFrameRef`) set `shouldClearCanvas = false`, suppressing the real background fill. Fresh content was then drawn *over* the previous composite, so the old position/scale of the clip remained visible around the new one.

**Fix (two parts, matching #93's description):**
1. The last-good-frame paste is now an **anti-flicker placeholder only** — it never suppresses clearing: the real background fill always runs before drawing fresh content.
2. The render-failure fallback now paints from the **cached composite bitmap** (`lastGoodFrameRef`) instead of the working offscreen buffer, which may hold stale/partially-drawn pixels.

## Secondary cleanup (from PR #87)

Removed the undefined `content-area-fix` class from the AI/Recipes/Templates tab wrappers in `AssetsPanel.tsx`. (The Graphics/Text/Effects/Transitions flex fixes from #87 already exist in main.)

## Verification

- `pnpm --filter @openreel/web typecheck` — clean
- Web tests: **816 passed / 7 skipped / 0 failed** (one flaky run produced a single transient failure; two subsequent runs are green)