### PR TITLE
feat(agent): add OpenRouter as BYOK LLM provider

### DIFF
--- a/apps/desktop/src/main/ipc/cloud.ts
+++ b/apps/desktop/src/main/ipc/cloud.ts
@@ -1,6 +1,6 @@
 import { getKeyStore } from "./keychain";
 
-export type CloudService = "elevenlabs" | "openai" | "anthropic";
+export type CloudService = "elevenlabs" | "openai" | "anthropic" | "openrouter";
 
 interface ServiceConfig {
   baseUrl: string;
@@ -21,6 +21,10 @@ export const DIRECT_CONFIG: Record<CloudService, ServiceConfig> = {
   anthropic: {
     baseUrl: "https://api.anthropic.com/v1",
     authHeaders: (key) => ({ "x-api-key": key, "anthropic-version": "2023-06-01" }),
+  },
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    authHeaders: (key) => ({ Authorization: `Bearer ${key}` }),
   },
 };
 

--- a/apps/web/functions/api/proxy/[[catchall]].ts
+++ b/apps/web/functions/api/proxy/[[catchall]].ts
@@ -38,6 +38,11 @@ const SERVICE_CONFIG: Record<string, ServiceConfig> = {
       "anthropic-version": "2023-06-01",
     }),
   },
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    allowedPaths: /^(chat\/completions|models)$/,
+    authHeaders: (key) => ({ Authorization: `Bearer ${key}` }),
+  },
 };
 
 const ALLOWED_ORIGINS = [

--- a/apps/web/src/components/editor/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/editor/chat/ProviderModelPicker.tsx
@@ -9,6 +9,7 @@ import { modelsFor, defaultModelFor } from "./models";
 const PROVIDERS: ReadonlyArray<{ id: LlmProvider; label: string }> = [
   { id: "anthropic", label: "Anthropic" },
   { id: "openai", label: "OpenAI" },
+  { id: "openrouter", label: "OpenRouter" },
 ];
 
 interface ProviderModelPickerProps {

--- a/apps/web/src/components/editor/inspector/hooks/useElevenLabsApi.ts
+++ b/apps/web/src/components/editor/inspector/hooks/useElevenLabsApi.ts
@@ -218,7 +218,13 @@ export function useElevenLabsApi(options: UseElevenLabsApiOptions): UseElevenLab
 
     const apiKey = isDesktop ? "" : (await getSecret(llmProvider)) ?? "";
     if (!isDesktop && !apiKey) {
-      throw new Error(`${llmProvider === "openai" ? "OpenAI" : "Anthropic"} API key not found. Add it in Settings > API Keys.`);
+      const label =
+        llmProvider === "anthropic"
+          ? "Anthropic"
+          : llmProvider === "openrouter"
+            ? "OpenRouter"
+            : "OpenAI";
+      throw new Error(`${label} API key not found. Add it in Settings > API Keys.`);
     }
 
     if (llmProvider === "anthropic") {
@@ -246,11 +252,14 @@ export function useElevenLabsApi(options: UseElevenLabsApiOptions): UseElevenLab
       return content?.[0]?.text ?? inputText;
     }
 
-    const response = await apiFetch("openai", "/chat/completions", apiKey, {
+    const service: "openai" | "openrouter" =
+      llmProvider === "openrouter" ? "openrouter" : "openai";
+    const model = llmProvider === "openrouter" ? "openai/gpt-5.4-mini" : "gpt-4o-mini";
+    const response = await apiFetch(service, "/chat/completions", apiKey, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        model: "gpt-4o-mini",
+        model,
         messages: [
           { role: "system", content: ENHANCE_SYSTEM_PROMPT },
           { role: "user", content: inputText },

--- a/apps/web/src/components/editor/settings/GeneralPanel.tsx
+++ b/apps/web/src/components/editor/settings/GeneralPanel.tsx
@@ -93,6 +93,7 @@ export const GeneralPanel: React.FC = () => {
     (s) =>
       s.id === "openai" ||
       s.id === "anthropic" ||
+      s.id === "openrouter" ||
       configuredServices.includes(s.id),
   );
 

--- a/apps/web/src/motion/components/GenerateShaderBox.tsx
+++ b/apps/web/src/motion/components/GenerateShaderBox.tsx
@@ -8,7 +8,7 @@ import { makeBYOKClient } from "../../services/agent/llm-transport";
 import { defaultModelFor, modelsFor } from "../../services/agent/models";
 import { getSecret, isSessionUnlocked } from "../../services/secure-storage";
 import { useProjectStore } from "../../stores/project-store";
-import { useSettingsStore } from "../../stores/settings-store";
+import { useSettingsStore, type LlmProvider } from "../../stores/settings-store";
 import { Button, Field, TextInput } from "./primitives";
 
 interface GenerateShaderBoxProps {
@@ -27,7 +27,7 @@ function isDesktop(): boolean {
   return typeof window !== "undefined" && window.openreel?.platform === "desktop";
 }
 
-function resolveModel(): { provider: "openai" | "anthropic"; model: string } {
+function resolveModel(): { provider: LlmProvider; model: string } {
   const provider = useSettingsStore.getState().defaultLlmProvider;
   const storedModel = useSettingsStore.getState().llmModel;
   const model = modelsFor(provider).some((option) => option.id === storedModel)
@@ -36,7 +36,7 @@ function resolveModel(): { provider: "openai" | "anthropic"; model: string } {
   return { provider, model };
 }
 
-async function resolveApiKey(provider: "openai" | "anthropic"): Promise<string | null> {
+async function resolveApiKey(provider: LlmProvider): Promise<string | null> {
   if (isDesktop()) return "";
   if (!isSessionUnlocked()) return null;
   try {

--- a/apps/web/src/services/agent/llm-transport.ts
+++ b/apps/web/src/services/agent/llm-transport.ts
@@ -11,6 +11,7 @@ import type { LlmProvider } from "../../stores/settings-store";
 const PATHS: Record<LlmProvider, string> = {
   anthropic: "/messages",
   openai: "/chat/completions",
+  openrouter: "/chat/completions",
 };
 
 function makeSend(

--- a/apps/web/src/services/agent/models.ts
+++ b/apps/web/src/services/agent/models.ts
@@ -19,6 +19,14 @@ export const LLM_MODELS: Record<LlmProvider, LlmModelOption[]> = {
     { id: "gpt-4.1", label: "GPT-4.1" },
     { id: "o4-mini", label: "o4-mini" },
   ],
+  openrouter: [
+    { id: "openai/gpt-5.4", label: "GPT-5.4 (OpenAI)" },
+    { id: "openai/gpt-5.4-mini", label: "GPT-5.4 mini (OpenAI)" },
+    { id: "google/gemini-3.6-flash", label: "Gemini 3.6 Flash (Google)" },
+    { id: "deepseek/deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+    { id: "nvidia/nemotron-3-ultra:free", label: "Nemotron 3 Ultra (free)" },
+    { id: "openai/gpt-oss-120b:free", label: "GPT-OSS 120B (free)" },
+  ],
 };
 
 export function defaultModelFor(provider: LlmProvider): string {

--- a/apps/web/src/services/api-proxy.ts
+++ b/apps/web/src/services/api-proxy.ts
@@ -29,6 +29,12 @@ const DIRECT_CONFIG = {
       "anthropic-dangerous-direct-browser-access": "true",
     }),
   },
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    authHeaders: (key: string): Record<string, string> => ({
+      Authorization: `Bearer ${key}`,
+    }),
+  },
 } as const;
 
 export type ApiService = keyof typeof DIRECT_CONFIG;

--- a/apps/web/src/stores/settings-store.ts
+++ b/apps/web/src/stores/settings-store.ts
@@ -33,6 +33,12 @@ export const SERVICE_REGISTRY: readonly ServiceConfig[] = [
     docsUrl: "https://docs.anthropic.com/en/docs",
   },
   {
+    id: "openrouter",
+    label: "OpenRouter",
+    description: "Unified gateway for 400+ models (GPT, Claude, Gemini, Llama, and more)",
+    docsUrl: "https://openrouter.ai/docs",
+  },
+  {
     id: "kie-ai",
     label: "Kie.ai",
     description: "AI aggregator for video/image generation, upscaling, and editing",
@@ -47,7 +53,7 @@ export const SERVICE_REGISTRY: readonly ServiceConfig[] = [
 ] as const;
 
 export type TtsProvider = "piper" | "elevenlabs";
-export type LlmProvider = "openai" | "anthropic";
+export type LlmProvider = "openai" | "anthropic" | "openrouter";
 export type AggregatorProvider = "kie-ai" | "freepik";
 export type SettingsTab = "general" | "api-keys" | "mcp";
 

--- a/apps/web/src/types/global.d.ts
+++ b/apps/web/src/types/global.d.ts
@@ -228,7 +228,7 @@ declare global {
       };
       cloud: {
         fetch(
-          service: "elevenlabs" | "openai" | "anthropic",
+          service: "elevenlabs" | "openai" | "anthropic" | "openrouter",
           path: string,
           options?: { method?: string; headers?: Record<string, string>; body?: string },
         ): Promise<{ status: number; statusText: string; headers: Record<string, string>; body: ArrayBuffer }>;

--- a/packages/agent-runner/src/cli.ts
+++ b/packages/agent-runner/src/cli.ts
@@ -26,9 +26,16 @@ function parseArgs(argv: string[]): CliArgs {
       case "-m":
         args.prompt = next();
         break;
-      case "--provider":
-        args.provider = next() === "openai" ? "openai" : "anthropic";
+      case "--provider": {
+        const value = next();
+        args.provider =
+          value === "openai"
+            ? "openai"
+            : value === "openrouter"
+              ? "openrouter"
+              : "anthropic";
         break;
+      }
       case "--model":
         args.model = next();
         break;
@@ -47,18 +54,19 @@ function parseArgs(argv: string[]): CliArgs {
 }
 
 function resolveApiKey(provider: LlmProvider): string {
-  return (
-    process.env.OPENREEL_API_KEY ??
-    (provider === "anthropic"
+  const providerEnv =
+    provider === "anthropic"
       ? process.env.ANTHROPIC_API_KEY
-      : process.env.OPENAI_API_KEY) ??
-    ""
-  );
+      : provider === "openrouter"
+        ? process.env.OPENROUTER_API_KEY
+        : process.env.OPENAI_API_KEY;
+  return process.env.OPENREEL_API_KEY ?? providerEnv ?? "";
 }
 
 const DEFAULT_MODEL: Record<LlmProvider, string> = {
   anthropic: "claude-sonnet-4-20250514",
   openai: "gpt-4o",
+  openrouter: "openai/gpt-5.4",
 };
 
 const USAGE = `openreel-agent — headless project editing
@@ -69,12 +77,12 @@ Usage:
 Options:
   -p, --project <path>   Project JSON to edit (required)
   -m, --prompt  <text>   Natural-language editing instruction (required)
-      --provider <name>  anthropic | openai (default: anthropic)
+      --provider <name>  anthropic | openai | openrouter (default: anthropic)
       --model <id>       Model id (default: provider default)
   -o, --out <path>       Output path (default: edit in place)
       --dry-run          Plan without applying mutations
 
-API key (never stored): OPENREEL_API_KEY, or ANTHROPIC_API_KEY / OPENAI_API_KEY.`;
+API key (never stored): OPENREEL_API_KEY, or ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY.`;
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
@@ -85,7 +93,13 @@ async function main(): Promise<void> {
   const apiKey = resolveApiKey(args.provider);
   if (!apiKey) {
     process.stderr.write(
-      `No API key found. Set OPENREEL_API_KEY (or ${args.provider === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY"}).\n`,
+      `No API key found. Set OPENREEL_API_KEY (or ${
+        args.provider === "anthropic"
+          ? "ANTHROPIC_API_KEY"
+          : args.provider === "openrouter"
+            ? "OPENROUTER_API_KEY"
+            : "OPENAI_API_KEY"
+      }).\n`,
     );
     process.exit(1);
   }

--- a/packages/agent-runner/src/node-llm.test.ts
+++ b/packages/agent-runner/src/node-llm.test.ts
@@ -34,6 +34,17 @@ describe("makeNodeLLMSend", () => {
     expect((init.headers as Record<string, string>).Authorization).toBe("Bearer sk-openai");
   });
 
+  it("routes openrouter to its endpoint with a Bearer key", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(okResponse({ ok: true }));
+    const send = makeNodeLLMSend("openrouter", "sk-or", fetchFn as unknown as typeof fetch);
+    await send({ model: "openai/gpt-5.4" });
+
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer sk-or");
+    expect(init.body).not.toContain("sk-or");
+  });
+
   it("throws when no key is provided", () => {
     expect(() => makeNodeLLMSend("anthropic", "")).toThrow(/Missing API key/);
   });

--- a/packages/agent-runner/src/node-llm.ts
+++ b/packages/agent-runner/src/node-llm.ts
@@ -6,11 +6,12 @@ import {
 } from "@openreel/agent";
 import type { LLMClient, LLMSend } from "@openreel/agent";
 
-export type LlmProvider = "anthropic" | "openai";
+export type LlmProvider = "anthropic" | "openai" | "openrouter";
 
 const ENDPOINTS: Record<LlmProvider, string> = {
   anthropic: "https://api.anthropic.com/v1/messages",
   openai: "https://api.openai.com/v1/chat/completions",
+  openrouter: "https://openrouter.ai/api/v1/chat/completions",
 };
 
 function authHeaders(
@@ -24,6 +25,7 @@ function authHeaders(
       "Content-Type": "application/json",
     };
   }
+  // OpenRouter uses the same Bearer scheme as OpenAI.
   return {
     Authorization: `Bearer ${apiKey}`,
     "Content-Type": "application/json",

--- a/packages/agent/src/llm.test.ts
+++ b/packages/agent/src/llm.test.ts
@@ -6,6 +6,7 @@ import {
   parseOpenAIResponse,
   AnthropicClient,
   OpenAIClient,
+  makeClientFromSend,
   type LoopMessage,
 } from "./llm";
 
@@ -94,5 +95,24 @@ describe("OpenAI normalization", () => {
     });
     const res = await client.complete({ messages: [{ role: "user", content: "hi" }], tools: [] });
     expect(res.text).toBe("yo");
+  });
+
+  it("makeClientFromSend maps openrouter to the OpenAI-compatible client", async () => {
+    let seenBody: unknown = null;
+    const client = makeClientFromSend({
+      provider: "openrouter",
+      model: "openai/gpt-5.4",
+      send: async (body) => {
+        seenBody = body;
+        return {
+          choices: [{ message: { content: "ok", tool_calls: [] }, finish_reason: "stop" }],
+          usage: { prompt_tokens: 1, completion_tokens: 2 },
+        };
+      },
+    });
+    const res = await client.complete({ messages: [{ role: "user", content: "hi" }], tools: [] });
+    expect((seenBody as { model: string }).model).toBe("openai/gpt-5.4");
+    expect(res.text).toBe("ok");
+    expect(res.usage).toEqual({ inputTokens: 1, outputTokens: 2 });
   });
 });

--- a/packages/agent/src/llm.ts
+++ b/packages/agent/src/llm.ts
@@ -7,7 +7,7 @@ export interface LLMToolUse {
 /** Informational only — the loop drives control flow off toolUses, not this. */
 export type LLMStopReason = "end_turn" | "tool_use" | "max_tokens";
 
-export type LlmProviderName = "anthropic" | "openai";
+export type LlmProviderName = "anthropic" | "openai" | "openrouter";
 
 export interface LLMUsage {
   readonly inputTokens: number;
@@ -357,6 +357,8 @@ export interface ClientFromSendOptions {
 /** Assembles the right provider client from an injected transport (shared by the web + node factories). */
 export function makeClientFromSend(opts: ClientFromSendOptions): LLMClient {
   const maxTokens = opts.maxTokens ?? 4096;
+  // OpenRouter speaks the OpenAI chat-completions protocol, so it reuses the
+  // OpenAI client (body + response parsing) with its own endpoint/transport.
   return opts.provider === "anthropic"
     ? new AnthropicClient({ model: opts.model, maxTokens, send: opts.send })
     : new OpenAIClient({ model: opts.model, maxTokens, send: opts.send });


### PR DESCRIPTION
## What

Adds **OpenRouter** as a first-class BYOK LLM provider across the agent stack. OpenRouter is OpenAI-compatible (chat completions protocol), so it reuses the existing OpenAI client with its own endpoint/transport — one key for GPT, Claude, Gemini, Llama, DeepSeek, and 400+ models. This is the foundation for the AI pipeline (vision analysis, transcription, moments detection) with a single credential.

## Wired end-to-end

| Layer | Change |
|---|---|
| `packages/agent` | `LlmProviderName` + `makeClientFromSend` routes openrouter → OpenAI-compatible client |
| `agent-runner` (headless) | `node-llm.ts` endpoint `https://openrouter.ai/api/v1/chat/completions` + Bearer auth; CLI `--provider openrouter`, `OPENROUTER_API_KEY`, default model |
| Web settings | `SERVICE_REGISTRY` entry (auto-appears in Settings > API Keys + GeneralPanel AI provider list) |
| Web transport | `apiFetch` DIRECT_CONFIG, BYOK `llm-transport` path, `ProviderModelPicker` + model list |
| Web features | `GenerateShaderBox` + text-enhancement hook use the selected provider (openai/anthropic/openrouter) |
| Desktop | `cloud.ts` CloudService + DIRECT_CONFIG mirror (keychain id = service) |
| Cloudflare Pages proxy | `/api/proxy/openrouter/chat/completions` + `/models` |

## Model defaults (curated for tool-calling)

- `openai/gpt-5.4` (default) · `openai/gpt-5.4-mini`
- `google/gemini-3.6-flash` · `deepseek/deepseek-v4-pro`
- Free: `nvidia/nemotron-3-ultra:free` · `openai/gpt-oss-120b:free`

Users can also type any OpenRouter model id in the chat model picker.

## Verification

- Typecheck: agent, agent-runner, web, desktop ✓
- `@openreel/agent`: **460 passed** · `@openreel/agent-runner`: **29 passed** · `@openreel/web`: **816 passed / 7 skipped** (149 files)
- New tests: openrouter endpoint/Bearer in `node-llm.test.ts`; `makeClientFromSend` openrouter mapping in `llm.test.ts`